### PR TITLE
Hardcode `data` layer for BPCells matrices

### DIFF
--- a/R/run_dge.R
+++ b/R/run_dge.R
@@ -126,7 +126,7 @@ run_dge.Seurat <-
       # Run BPCells marker_features
       dge_table <-
         BPCells::marker_features(
-          mat = object[[seurat_assay]]@layers[[slot]],
+          mat = object[[seurat_assay]][[slot]],
           groups = groups,
           method = "wilcoxon"
           )

--- a/R/run_dge.R
+++ b/R/run_dge.R
@@ -126,7 +126,7 @@ run_dge.Seurat <-
       # Run BPCells marker_features
       dge_table <-
         BPCells::marker_features(
-          mat = object[[seurat_assay]][[slot]],
+          mat = object[[seurat_assay]]$data,
           groups = groups,
           method = "wilcoxon"
           )


### PR DESCRIPTION
Wilcoxon rank-sum tests will always be run on normalized data, which is stored in `data` in Seurat objects.