### PR TITLE
14: fix error with DGE on BPCells backed objects

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: scDE
 Type: Package
 Title: Unified Single Cell Differential Expression
-Version: 0.2.0.9000
+Version: 0.2.1.9000
 Authors@R: 
     c(
     person("William", "Showers", email = "bill.showers@refinedscience.com", role = c("aut", "cre")),

--- a/R/run_dge.R
+++ b/R/run_dge.R
@@ -165,6 +165,15 @@ run_dge.Seurat <-
           return_class = "vector"
           )
 
+      # Drop unused factor levels. BPCells::marker_features() coerces the
+      # group vector with as.factor() and sizes its result tibble from
+      # levels(groups), but the underlying Wilcoxon test only emits stats
+      # for populated groups. Unused levels make the sizes diverge and
+      # tibble::tibble() errors with "columns must have compatible sizes".
+      if (is.factor(groups)) {
+        groups <- droplevels(groups)
+      }
+
       # Run BPCells marker_features
       dge_table <-
         BPCells::marker_features(


### PR DESCRIPTION
This fixes #14. 

BPCells::marker_features() sizes its result tibble from levels(groups)
but the Wilcoxon stats only cover populated groups, resulting in an error. This has been fixed by dropping unused levels from group factors before performing DGE on BPCells objects.