### PR TITLE
Correct failing GitHub action

### DIFF
--- a/R/run_dge.R
+++ b/R/run_dge.R
@@ -332,8 +332,6 @@ run_dge.AnnDataR6 <-
     remove_raw_pval = FALSE,
     slot = lifecycle::deprecated()
   ){
-    library(reticulate)
-
     # Source fetch_anndata python script
     python_path =
       system.file(
@@ -343,12 +341,13 @@ run_dge.AnnDataR6 <-
         package = "scDE"
       )
 
-    reticulate::source_python(python_path)
+    py_env <- new.env()
+    reticulate::source_python(python_path, envir = py_env)
 
     # Run DGE via scanpy.tl.rank_genes_groups,
     # Return table
     dge_table <-
-      py$scanpy_dge(
+      py_env$scanpy_dge(
         adata = object,
         group_by = group_by,
         method = "wilcoxon"


### PR DESCRIPTION
Issue #18 was due to a `py` lookup that failed due to reticulate not being reliably initialized. This was addressed by creating a separate environment and then sourcing the python script into that environment. The new environment can then be called instead of `py`.   